### PR TITLE
Changed the way we configure the application status report

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"github.com/hashicorp-dev-advocates/waypoint-client/pkg/client"
+	gen "github.com/hashicorp-dev-advocates/waypoint-client/pkg/waypoint"
 	"github.com/kr/pretty"
 	"log"
 	"os"
+	"time"
 )
 
 var token string
@@ -27,37 +29,34 @@ func main() {
 		log.Fatal(err)
 	}
 
-	//gc := client.Git{
-	//	Url:  "https://github.com/hashicorp/waypoint-examples",
-	//	Path: "docker/go",
-	//}
-	//
-	//projconf := client.DefaultProjectConfig()
-	//
-	//projconf.Name = "robbarnes"
-	//projconf.RemoteRunnersEnabled = false
-	//projconf.GitPollInterval = 30 * time.Second
-	//
-	//var1 := client.SetVariable()
-	//var1.Name = "name"
-	//var1.Value = &gen.Variable_Str{Str: "Devops Rob"}
-	//
-	//var2 := client.SetVariable()
-	//var2.Name = "role"
-	//var2.Value = &gen.Variable_Str{Str: "Developer Advocate"}
-	//
-	//var varList []*gen.Variable
-	//
-	//varList = append(varList, &var1, &var2)
-	//projconf.StatusReportPoll = &gen.Project_AppStatusPoll{
-	//	Enabled:  true,
-	//	Interval: "10m",
-	//}
-	//
-	//npr, err := wp.UpsertProject(context.TODO(), projconf, &gc, varList)
-	//if err != nil {
-	//	panic(err)
-	//}
+	gc := client.Git{
+		Url:  "https://github.com/hashicorp/waypoint-examples",
+		Path: "docker/go",
+	}
+
+	projconf := client.DefaultProjectConfig()
+
+	projconf.Name = "robbarnes"
+	projconf.RemoteRunnersEnabled = false
+	projconf.GitPollInterval = 30 * time.Second
+
+	var1 := client.SetVariable()
+	var1.Name = "name"
+	var1.Value = &gen.Variable_Str{Str: "Devops Rob"}
+
+	var2 := client.SetVariable()
+	var2.Name = "role"
+	var2.Value = &gen.Variable_Str{Str: "Developer Advocate"}
+
+	var varList []*gen.Variable
+
+	varList = append(varList, &var1, &var2)
+	projconf.StatusReportPoll = 0 * time.Second
+
+	npr, err := wp.UpsertProject(context.TODO(), projconf, &gc, varList)
+	if err != nil {
+		panic(err)
+	}
 
 	//gpr, err := wp.GetProject(context.TODO(), "robbarnes")
 	//if err != nil {
@@ -66,4 +65,5 @@ func main() {
 
 	prl, err := wp.ListProject(context.TODO())
 	pretty.Println(prl)
+	pretty.Println(npr)
 }

--- a/pkg/client/projects.go
+++ b/pkg/client/projects.go
@@ -33,7 +33,7 @@ type ProjectConfig struct {
 	// Application polling settings.
 	// Polling will trigger a "StatusFunc" for collecting
 	// a report on the current status of the application.
-	StatusReportPoll *gen.Project_AppStatusPoll
+	StatusReportPoll time.Duration
 }
 
 func DefaultProjectConfig() ProjectConfig {
@@ -47,7 +47,7 @@ func DefaultProjectConfig() ProjectConfig {
 		WaypointHclFormat: 0,
 		FileChangeSignal:  "",
 		Variables:         nil,
-		StatusReportPoll:  nil,
+		StatusReportPoll:  0,
 	}
 }
 
@@ -186,6 +186,11 @@ func (c *waypointImpl) UpsertProject(
 		Interval: projectConfig.GitPollInterval.String(),
 	}
 
+	statusReportPoll := &gen.Project_AppStatusPoll{
+		Enabled:  projectConfig.StatusReportPoll > 0,
+		Interval: projectConfig.StatusReportPoll.String(),
+	}
+
 	upr := &gen.UpsertProjectRequest{
 		Project: &gen.Project{
 			Name:              projectConfig.Name,
@@ -196,7 +201,7 @@ func (c *waypointImpl) UpsertProject(
 			WaypointHclFormat: projectConfig.WaypointHclFormat,
 			FileChangeSignal:  projectConfig.FileChangeSignal,
 			Variables:         variables,
-			StatusReportPoll:  projectConfig.StatusReportPoll,
+			StatusReportPoll:  statusReportPoll,
 		},
 	}
 


### PR DESCRIPTION
Changed the way we configure the application status report to match the logic of the git poll interval. It now expects a time.Duration  argument and will enable the poll by default if the dureation given is > 0.